### PR TITLE
feat(tokens): Handle automatic token refresh

### DIFF
--- a/src/scripts/find-posts-by-hashtag.js
+++ b/src/scripts/find-posts-by-hashtag.js
@@ -1,14 +1,9 @@
 const { inspect } = require('node:util');
-const dotenv = require('dotenv');
 const { SuperfaceClient } = require('@superfaceai/one-sdk');
-const { getTokens } = require('../tokens-utils');
-
-dotenv.config();
+const { withAccessToken } = require('../tokens-utils');
 
 const findPostsByHashtag = async (hashtag) => {
   const sdk = new SuperfaceClient();
-
-  const { accessToken } = getTokens();
 
   try {
     const provider = await sdk.getProvider('twitter');
@@ -18,15 +13,17 @@ const findPostsByHashtag = async (hashtag) => {
 
     //read up to 3 pages of posts
     for (let i = 0; i < 3; i++) {
-      console.log(`Getting page #${i + 1}`);
-      const result = await profile.getUseCase('FindByHashtag').perform(
-        { hashtag, page },
-        {
-          provider,
-          parameters: {
-            accessToken,
-          },
-        }
+      console.error(`Getting page #${i + 1}`);
+      const result = await withAccessToken((accessToken) =>
+        profile.getUseCase('FindByHashtag').perform(
+          { hashtag, page },
+          {
+            provider,
+            parameters: {
+              accessToken,
+            },
+          }
+        )
       );
       unwrappedResult = result.unwrap();
 

--- a/src/scripts/find-posts-by-mention.js
+++ b/src/scripts/find-posts-by-mention.js
@@ -1,26 +1,24 @@
 const { inspect } = require('node:util');
-const dotenv = require('dotenv');
 const { SuperfaceClient } = require('@superfaceai/one-sdk');
-const { getTokens } = require('../tokens-utils');
+const { withAccessToken } = require('../tokens-utils');
 
-dotenv.config();
-
-const findPostsByHashtag = async (profileId, page) => {
+const findPostsByMention = async (profileId, page) => {
   const sdk = new SuperfaceClient();
-
-  const { accessToken } = getTokens();
 
   try {
     const provider = await sdk.getProvider('twitter');
     const profile = await sdk.getProfile('social-media/posts-lookup');
-    const result = await profile.getUseCase('FindByMention').perform(
-      { profileId, page },
-      {
-        provider,
-        parameters: {
-          accessToken,
-        },
-      }
+
+    const result = await withAccessToken((accessToken) =>
+      profile.getUseCase('FindByMention').perform(
+        { profileId, page },
+        {
+          provider,
+          parameters: {
+            accessToken,
+          },
+        }
+      )
     );
     console.log(inspect(result.unwrap(), false, Infinity, true));
   } catch (err) {
@@ -28,6 +26,6 @@ const findPostsByHashtag = async (profileId, page) => {
   }
 };
 
-const profileId = process.argv[2] || '1466796521412771840';
+const profileId = process.argv[2] || '1196797704015400960'; // @superfaceai
 
-findPostsByHashtag(profileId);
+findPostsByMention(profileId);

--- a/src/scripts/followers.js
+++ b/src/scripts/followers.js
@@ -1,33 +1,31 @@
 const { inspect } = require('node:util');
-const dotenv = require('dotenv');
 const { SuperfaceClient } = require('@superfaceai/one-sdk');
-const { getTokens } = require('../tokens-utils');
-
-dotenv.config();
+const { withAccessToken } = require('../tokens-utils');
 
 const printFollowers = async (profileId) => {
   const sdk = new SuperfaceClient();
 
-  const { accessToken } = getTokens();
-
   try {
     const provider = await sdk.getProvider('twitter');
     const profile = await sdk.getProfile('social-media/followers');
-    const result = await profile.getUseCase('GetFollowers').perform(
-      { profileId },
-      {
-        provider,
-        parameters: {
-          accessToken,
-        },
-      }
+    const result = await withAccessToken((accessToken) =>
+      profile.getUseCase('GetFollowers').perform(
+        { profileId },
+        {
+          provider,
+          parameters: {
+            accessToken,
+          },
+        }
+      )
     );
+
     console.log(inspect(result.unwrap(), false, Infinity, true));
   } catch (err) {
     console.error(inspect(err, false, Infinity, true));
   }
 };
 
-const profileId = process.argv[2] || '1466796521412771840';
+const profileId = process.argv[2] || '1196797704015400960'; // @superfaceai
 
 printFollowers(profileId);

--- a/src/scripts/publish-post.js
+++ b/src/scripts/publish-post.js
@@ -1,28 +1,25 @@
 const { inspect } = require('node:util');
-const dotenv = require('dotenv');
 const { SuperfaceClient } = require('@superfaceai/one-sdk');
-const { getTokens } = require('../tokens-utils');
-
-dotenv.config();
+const { withAccessToken } = require('../tokens-utils');
 
 const publishPost = async (message) => {
   const sdk = new SuperfaceClient();
 
-  const { accessToken } = getTokens();
-
   try {
     const provider = await sdk.getProvider('twitter');
     const profile = await sdk.getProfile('social-media/publish-post');
-    const result = await profile.getUseCase('PublishPost').perform(
-      {
-        text: message,
-      },
-      {
-        provider,
-        parameters: {
-          accessToken,
+    const result = await withAccessToken((accessToken) =>
+      profile.getUseCase('PublishPost').perform(
+        {
+          text: message,
         },
-      }
+        {
+          provider,
+          parameters: {
+            accessToken,
+          },
+        }
+      )
     );
     console.log(inspect(result.unwrap(), false, Infinity, true));
   } catch (err) {

--- a/src/scripts/publishing-profiles.js
+++ b/src/scripts/publishing-profiles.js
@@ -1,26 +1,23 @@
 const { inspect } = require('node:util');
-const dotenv = require('dotenv');
 const { SuperfaceClient } = require('@superfaceai/one-sdk');
-const { getTokens } = require('../tokens-utils');
-
-dotenv.config();
+const { withAccessToken } = require('../tokens-utils');
 
 const printPublishingProfiles = async () => {
   const sdk = new SuperfaceClient();
 
-  const { accessToken } = getTokens();
-
   try {
     const provider = await sdk.getProvider('twitter');
     const profile = await sdk.getProfile('social-media/publishing-profiles');
-    const result = await profile.getUseCase('GetProfilesForPublishing').perform(
-      {},
-      {
-        provider,
-        parameters: {
-          accessToken,
-        },
-      }
+    const result = await withAccessToken((accessToken) =>
+      profile.getUseCase('GetProfilesForPublishing').perform(
+        {},
+        {
+          provider,
+          parameters: {
+            accessToken,
+          },
+        }
+      )
     );
     console.log(inspect(result.unwrap(), false, Infinity, true));
   } catch (err) {

--- a/src/tokens-utils.js
+++ b/src/tokens-utils.js
@@ -1,7 +1,75 @@
-const tokens = require('../tokens.json');
+const { readFile, writeFile } = require('fs/promises');
+const path = require('path');
+const { SuperfaceClient } = require('@superfaceai/one-sdk');
+require('dotenv').config();
 
-function getTokens() {
-  return tokens;
+const TOKENS_FILE = path.join(__dirname, '..', 'tokens.json');
+
+const sdk = new SuperfaceClient();
+
+let _tokensCache;
+
+async function loadTokens() {
+  try {
+    const contents = await readFile(TOKENS_FILE, { encoding: 'utf-8' });
+    const parsed = JSON.parse(contents);
+    return parsed;
+  } catch (err) {
+    throw new Error('Failed to load tokens', { cause: err });
+  }
 }
 
-module.exports = { getTokens };
+async function getTokens() {
+  if (!_tokensCache) {
+    _tokensCache = await loadTokens();
+  }
+  return _tokensCache;
+}
+
+async function saveTokens(newTokens) {
+  return await writeFile(TOKENS_FILE, JSON.stringify(newTokens), {
+    encoding: 'utf-8',
+  });
+}
+
+async function getRefreshedTokens() {
+  console.error('Refreshing token');
+
+  const tokens = await getTokens();
+  const profile = await sdk.getProfile('oauth2/refresh-token');
+  const result = await profile
+    .getUseCase('GetAccessTokenFromRefreshToken')
+    .perform({
+      refreshToken: tokens.refreshToken,
+      clientId: process.env.TWITTER_CLIENT_ID,
+      clientSecret: process.env.TWITTER_CLIENT_SECRET,
+    });
+
+  const data = result.unwrap();
+  const expiresAt = Date.now() + data.expiresIn * 1000;
+
+  return { ...data, expiresAt };
+}
+
+async function refreshToken() {
+  const newTokens = await getRefreshedTokens();
+  await saveTokens(newTokens);
+  _tokensCache = newTokens;
+  return _tokensCache;
+}
+
+/**
+ * Passes current access token to the passed `perform` function and retries it with refreshed token if any exception occurs.
+ */
+async function withAccessToken(perform) {
+  const tokens = await getTokens();
+  try {
+    return await perform(tokens.accessToken);
+  } catch (err) {
+    console.error('Error, refreshing token', err);
+    const { accessToken } = refreshToken();
+    return await perform(accessToken);
+  }
+}
+
+module.exports = { withAccessToken };

--- a/superface/grid/oauth2/refresh-token@1.0.0.supr
+++ b/superface/grid/oauth2/refresh-token@1.0.0.supr
@@ -1,0 +1,76 @@
+name = "oauth2/refresh-token"
+version = "1.0.0"
+
+"""
+Get Access Token from Refresh Token
+Issue a new access token based on previously issued refresh token for OAuth 2.0 compatible providers.
+Client authentication can be provided directly as input, or, if supported, set as provider parameter.
+"""
+usecase GetAccessTokenFromRefreshToken unsafe {
+  input {
+    """
+    Refresh Token
+    The refresh token previously issued to the client.
+    """
+    refreshToken! string!
+
+    """
+    Client ID
+    Client authentication; may be also accepted as provider parameter.
+    """
+    clientId string!
+
+    """
+    Client Secret
+    Client authentication; may be also accepted as provider parameter.
+    """
+    clientSecret string!
+  }
+
+  result {
+    """
+    Access Token
+    Newly issued access token
+    """
+    accessToken! string!
+    """
+    Expires in (seconds)
+    Duration of time the access token is granted for.
+    """
+    expiresIn number!
+    """
+    Scopes
+    Authorized scopes for the issued access token.
+    """
+    scopes [string]
+    """
+    Token type
+    The type of token this is, usually "Bearer".
+    """
+    tokenType string
+
+    """
+    Refresh token
+    Provider may issue a new refresh token, invalidating the previously used refresh token
+    """
+    refreshToken string
+  }
+
+  error {
+    "Error code"
+    error enum {
+      invalid_request
+      invalid_client
+      invalid_grant
+      invalid_scope
+      unauthorized_client
+      unsupported_grant_type
+      // If we cannot map the error code:
+      unknown_response
+    }
+    "Error description"
+    description
+    "Link with error detail"
+    link
+  }
+}

--- a/superface/super.json
+++ b/superface/super.json
@@ -23,6 +23,15 @@
       "priority": [
         "twitter"
       ]
+    },
+    "oauth2/refresh-token": {
+      "version": "1.0.0",
+      "providers": {
+        "twitter": {}
+      },
+      "priority": [
+        "twitter"
+      ]
     }
   },
   "providers": {


### PR DESCRIPTION
This introduces a full flow for refreshing tokens via [oauth2/refresh-token](https://superface.ai/oauth2/refresh-token) profile. This is hidden behind `withAccessToken` function which:

- loads tokens from `tokens.json` file,
- calls passed in perform function with loaded access token
- if perform raises an exception, then
  - uses refresh token to retrieve a new access and refresh tokens
  - stores them into `tokens.json`
  - reruns perform one more time with the refreshed access token

This reflects that Twitter uses refresh token only once and should make it easier to rerun the scripts even after the access token expired.

Additionally I have also adjusted default profile IDs to that of `superfaceai` profile.

What is missing is more proper check for the error returned from perform, since not all profiles easily detectable error about expired token.